### PR TITLE
Add ability to specify rules for 3 field in resend email

### DIFF
--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -429,17 +429,24 @@ class MailResource extends Resource
             ]);
     }
 
+    protected static function getResendFormRules():array{
+        return [];
+    }
+
     private static function getResendForm(): array
     {
         return [
             TagsInput::make('to')
+                ->nestedRecursiveRules(static::getResendFormRules())
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('Recipient(s)'))
                 ->required(),
             TagsInput::make('cc')
+                ->nestedRecursiveRules(static::getResendFormRules())
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('CC')),
             TagsInput::make('bcc')
+                ->nestedRecursiveRules(static::getResendFormRules())
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('BCC')),
         ];


### PR DESCRIPTION
Users can overwrite `getResendFormRules()` in their resource in order to pass an array of rules to `nestedRecursiveRules()`

Had to use `static::getResendFormRules()` to get the rules