### PR TITLE
Fix v4 issues

### DIFF
--- a/resources/views/mails/preview.blade.php
+++ b/resources/views/mails/preview.blade.php
@@ -1,6 +1,6 @@
 <div class="w-full h-screen">
     <iframe
         src="{{ route('filament.' . Filament\Facades\Filament::getCurrentPanel()->getId() . '.mails.preview', ['tenant' => Filament\Facades\Filament::getTenant(), 'mail' => $mail->id]) }}"
-        class="w-full h-full max-w-full" style="width: 100vw; height: 100vh; border: none;">
+        class="w-full h-full max-w-full" style="width: 100%; height: 100vh; border: none;">
     </iframe>
 </div>

--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -244,14 +244,12 @@ class MailResource extends Resource
                                 Tab::make('Preview')
                                     ->extraAttributes(['class' => 'w-full max-w-full'])
                                     ->schema([
-                                        TextEntry::make('html')
+                                        ViewEntry::make('html')
                                             ->hiddenLabel()
                                             ->label(__('HTML Content'))
                                             ->extraAttributes(['class' => 'overflow-x-auto'])
-                                            ->formatStateUsing(fn (string $state, Mail $record): View => view(
-                                                'filament-mails::mails.preview',
-                                                ['html' => $state, 'mail' => $record],
-                                            )),
+                                            ->view('filament-mails::mails.preview')
+                                            ->viewData(fn (string $state, Mail $record) => ['html' => $state, 'mail' => $record]),
                                     ]),
                                 Tab::make('HTML')
                                     ->schema([

--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -95,22 +95,22 @@ class MailResource extends Resource
                                                     ->label(__('Subject')),
                                                 TextEntry::make('from')
                                                     ->label(__('From'))
-                                                    ->getStateUsing(fn (Mail $record) => self::formatMailState($record->from)),
+                                                    ->formatStateUsing(fn (Mail $record) => self::formatMailState($record->from)),
                                                 TextEntry::make('to')
                                                     ->label(__('Recipient(s)'))
-                                                    ->getStateUsing(fn (Mail $record) => self::formatMailState($record->to)),
+                                                    ->formatStateUsing(fn (Mail $record) => self::formatMailState($record->to)),
                                                 TextEntry::make('cc')
                                                     ->label(__('CC'))
                                                     ->default('-')
-                                                    ->getStateUsing(fn (Mail $record) => self::formatMailState($record->cc ?? [])),
+                                                    ->formatStateUsing(fn (Mail $record) => self::formatMailState($record->cc ?? [])),
                                                 TextEntry::make('bcc')
                                                     ->label(__('BCC'))
                                                     ->default('-')
-                                                    ->getStateUsing(fn (Mail $record) => self::formatMailState($record->bcc ?? [])),
+                                                    ->formatStateUsing(fn (Mail $record) => self::formatMailState($record->bcc ?? [])),
                                                 TextEntry::make('reply_to')
                                                     ->default('-')
                                                     ->label(__('Reply To'))
-                                                    ->getStateUsing(fn (Mail $record) => self::formatMailState($record->reply_to ?? [])),
+                                                    ->formatStateUsing(fn (Mail $record) => self::formatMailState($record->reply_to ?? [])),
                                             ]),
                                     ]),
                                 Tab::make(__('Statistics'))
@@ -305,7 +305,7 @@ class MailResource extends Resource
                                             ->label(__('Mime Type')),
                                         ViewEntry::make('uuid')
                                             ->label(__('Download'))
-                                            ->getStateUsing(fn ($record) => $record)
+                                            ->formatStateUsing(fn ($record) => $record)
                                             ->view('filament-mails::mails.download'),
                                     ]),
                             ]),
@@ -352,7 +352,7 @@ class MailResource extends Resource
                 TextColumn::make('to')
                     ->label(__('Recipient(s)'))
                     ->limit(50)
-                    ->getStateUsing(fn (Mail $record) => self::formatMailState(emails: $record->to, mailOnly: true))
+                    ->formatStateUsing(fn (Mail $record) => self::formatMailState(emails: $record->to, mailOnly: true))
                     ->sortable()
                     ->searchable(),
                 TextColumn::make('opens')

--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -349,8 +349,8 @@ class MailResource extends Resource
                     ->label('')
                     ->alignLeft()
                     ->searchable(false)
-                    ->getStateUsing(fn (Mail $record) => $record->attachments->count() > 0)
-                    ->icon(fn (string $state): string => $state ? 'heroicon-o-paper-clip' : ''),
+                    ->getStateUsing(fn (Mail $record) => $record->attachments->count() > 0 ? true : null)
+                    ->icon('heroicon-o-paper-clip'),
                 TextColumn::make('to')
                     ->label(__('Recipient(s)'))
                     ->limit(50)


### PR DESCRIPTION
Currently, returning '' as the state fails, as it tries to render that as a column. 

as per the getIcon method,
```php
   public function getIcon(mixed $state): string | BackedEnum | null
    {
        if ($state === null) {
            return null;
        }
 ```
 This is a more reliable way.