### PR TITLE
fix: Use navigation.group configuration in MailResource

### DIFF
--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -58,7 +58,7 @@ class MailResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return __('Emails');
+        return config('filament-mails.navigation.group', __('Emails'));
     }
 
     public static function getNavigationLabel(): string


### PR DESCRIPTION
## Summary

- Fixes the MailResource to use the `filament-mails.navigation.group` configuration option
- Previously the navigation group was hardcoded to `__('Emails')` ignoring the config
- Now reads from config with a fallback to the previous default value

## Details

The issue was in `src/Resources/MailResource.php:61` where `getNavigationGroup()` returned a hardcoded value instead of checking the configuration.

**Before:**
```php
public static function getNavigationGroup(): ?string
{
    return __('Emails');
}
```

**After:**
```php
public static function getNavigationGroup(): ?string
{
    return config('filament-mails.navigation.group', __('Emails'));
}
```

## Test plan

- [x] Verified the configuration option exists in `config/filament-mails.php`
- [x] Confirmed EventResource and SuppressionResource already properly reference MailResource's navigation group
- [x] Change maintains backward compatibility with fallback to previous default

Closes #58

🤖 Generated with [Claude Code](https://claude.ai/code)