### PR TITLE
feat: add navigation sort configuration to MailResource

### DIFF
--- a/config/filament-mails.php
+++ b/config/filament-mails.php
@@ -13,5 +13,6 @@ return [
 
     'navigation' => [
         'group' => null,
+        'sort' => null,
     ],
 ];

--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -61,6 +61,11 @@ class MailResource extends Resource
         return config('filament-mails.navigation.group', __('Emails'));
     }
 
+    public static function getNavigationSort(): ?int
+    {
+        return config('filament-mails.navigation.sort');
+    }
+
     public static function getNavigationLabel(): string
     {
         return __('Emails');


### PR DESCRIPTION
# Make MailResource navigation order configurable

## Summary
- Add a `navigation.sort` option to `config/filament-mails.php` so the MailResource position can be adjusted from configuration.
- Implement `getNavigationSort()` in `MailResource` to read and cast that value, falling back to Filament's default ordering when it is unset.

Related to #58
